### PR TITLE
Add Support for GBRPlus Patched ESM to Swap Feature

### DIFF
--- a/Mopy/bash/basher/links_init.py
+++ b/Mopy/bash/basher/links_init.py
@@ -462,6 +462,7 @@ def InitModLinks():
         versionsMenu.links.append(Mods_OblivionVersion(u'1.1b'))
         versionsMenu.links.append(Mods_OblivionVersion(u'GOTY non-SI'))
         versionsMenu.links.append(Mods_OblivionVersion(u'SI'))
+        versionsMenu.links.append(Mods_OblivionVersion(u'GBR SI'))
         ModList.column_links.append(versionsMenu)
         ModList.column_links.append(SeparatorLink())
     ModList.column_links.append(Mods_ListMods())
@@ -630,6 +631,7 @@ def InitModLinks():
         versions_menu.links.append(Mods_OblivionVersion(u'1.1b'))
         versions_menu.links.append(Mods_OblivionVersion(u'GOTY non-SI'))
         versions_menu.links.append(Mods_OblivionVersion(u'SI'))
+        versions_menu.links.append(Mods_OblivionVersion(u'GBR SI'))
         edit_menu.append(versions_menu)
     if bush.game.allTags:
         edit_menu.append(SeparatorLink())

--- a/Mopy/bash/bosh/__init__.py
+++ b/Mopy/bash/bosh/__init__.py
@@ -60,7 +60,7 @@ from ..mod_files import ModFile, ModHeaderReader
 
 # Singletons, Constants -------------------------------------------------------
 reOblivion = re.compile(
-    u'^(Oblivion|Nehrim)(|_SI|_1.1|_1.1b|_1.5.0.8|_GOTY non-SI).esm$', re.U)
+    u'^(Oblivion|Nehrim)(|_SI|_1.1|_1.1b|_1.5.0.8|_GOTY non-SI|_GBR SI).esm$', re.U)
 # quick or auto save.bak(.bak...)
 bak_file_pattern = re.compile(u'' r'(quick|auto)(save)(\.bak)+(f?)$',
                               re.I | re.U)
@@ -1850,6 +1850,7 @@ class ModInfos(FileInfos):
             u'1.1b':       247388894, # Arthmoor has this size.
             u'GOTY non-SI':247388812, # GOTY version
             u'SI':         277504985} # Shivering Isles 1.2
+            u'GBR SI':     260913417} # GBR Main File Patch
         self.size_voVersion = {y:x for x, y in self.version_voSize.iteritems()}
         self.voCurrent = None
         self.voAvailable = set()


### PR DESCRIPTION
Add support for [<https://www.nexusmods.com/oblivion/mods/49349>] to ESM Swap feature.

May not include all necessary changes to be functional.

Under issue [<https://github.com/wrye-bash/wrye-bash/issues/400>].